### PR TITLE
Named Placeholders in Utterances and response belief containing calling intention

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Refer to https://prosody.im/download/start for details
 `brew install portaudio`
 
 ### 3. PyAudio
-Remove pyaudio from `requirements.txt`, because it cant be insalled with the default pip install command. Use instead the following:
+Remove pyaudio from `requirements.txt`, because it can't be installed with the default pip install command. Use instead the following:
 
 `pip install --global-option='build_ext' --global-option='-I/usr/local/include' --global-option='-L/usr/local/lib' pyaudio`
 Refer to https://gist.github.com/jiaaro/9767512210a1d80a8a0d#gistcomment-3023216 if this is not working
@@ -43,5 +43,5 @@ While being in the venv
 
 
 ### Naming
-Intention refers to intentions/functions within AgentSpeak(L)
-Intent refers to intents detected in user se by Wit.ai
+- **Intention** refers to intentions/functions within AgentSpeak(L)
+- **Intent** refers to intents detected in user response returned by Wit.ai

--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ Refer to https://gist.github.com/jiaaro/9767512210a1d80a8a0d#gistcomment-3023216
 While being in the venv
 `python main.py`
 
+
+### Naming
+Intention refers to intentions/functions within AgentSpeak(L)
+Intent refers to intents detected in user se by Wit.ai

--- a/asl/ava/io_intentions.asl
+++ b/asl/ava/io_intentions.asl
@@ -3,14 +3,16 @@ statement_iterator(0).
 
 +!expect_response(UtteranceID, FillIns) <-
     usercontroller(UserJID);
-    .send(UserJID, expect_response, [utterance_id(UtteranceID), eliciting_intention("my_test_intention"), fill_ins(FillIns)]).
+    .get_parent_intention(PI);
+    .send(UserJID, expect_response, [utterance_id(UtteranceID), eliciting_intention(PI), fill_ins(FillIns)]).
 
 +!expect_response(UtteranceID) <-
     !expect_response(UtteranceID, []).
 
 +!statement(UtteranceID, FillIns) <-
     usercontroller(UserJID);
-    .send(UserJID, statement, [UtteranceID, FillIns]);
+    .get_parent_intention(PI);
+    .send(UserJID, statement, [utterance_id(UtteranceID), eliciting_intention(PI), fill_ins(FillIns)]);
     -+statement_finished(UtteranceID, no);
     while(not statement_finished(UtteranceID, yes)){
         statement_iterator(X);

--- a/asl/ava/io_intentions.asl
+++ b/asl/ava/io_intentions.asl
@@ -3,7 +3,7 @@ statement_iterator(0).
 
 +!expect_response(UtteranceID, FillIns) <-
     usercontroller(UserJID);
-    .send(UserJID, expect_response, [UtteranceID, FillIns]).
+    .send(UserJID, expect_response, [utterance_id(UtteranceID), eliciting_intention("my_test_intention"), fill_ins(FillIns)]).
 
 +!expect_response(UtteranceID) <-
     !expect_response(UtteranceID, []).

--- a/asl/ava/main.asl
+++ b/asl/ava/main.asl
@@ -3,7 +3,7 @@
 {include("time.asl")}
 // !main gets called from environment
 
-
+!ask_user_xx.
 
 +!main <-
     .log("ava from asl", _);
@@ -19,9 +19,3 @@
     
 +response("default/prompt", Intent, Entities) <-
     !expect_response("default/prompt").
-
-
-
-
-+!test_get_intention <-
-    .print("test_intention").

--- a/asl/ava/main.asl
+++ b/asl/ava/main.asl
@@ -19,3 +19,9 @@
     
 +response("default/prompt", Intent, Entities) <-
     !expect_response("default/prompt").
+
+
+
+
++!test_get_intention <-
+    .print("test_intention").

--- a/asl/ava/main.asl
+++ b/asl/ava/main.asl
@@ -3,7 +3,6 @@
 {include("time.asl")}
 // !main gets called from environment
 
-!ask_user_xx.
 
 +!main <-
     .log("ava from asl", _);

--- a/asl/ava/time.asl
+++ b/asl/ava/time.asl
@@ -15,14 +15,14 @@ confirmed(person, "Lauren").
     confirmed(day, Day);
     schedule(Day, arrival_home, ArrivalHome);
     suggestion_for_user(time, Day, Time);
-    !expect_response("time/suggestion/home_arrival_1", [ArrivalHome, Time]).
+    !expect_response("/time/suggestion/home_arrival_1", [arrival_home(ArrivalHome), Time]).
     
     
-+response("time/suggestion/home_arrival_1", confirmation, InputValues) <-
++response("/time/suggestion/home_arrival_1", confirmation, InputValues) <-
     .log("confirmation received", _);
     !indicate_switch_person.
 
     
 +!indicate_switch_person <-
     confirmed(person, Person);
-    !statement("operational/switch_person_1", [Person]).
+    !statement("/operational/switch_person_1", [Person]).

--- a/asl/ava/time.asl
+++ b/asl/ava/time.asl
@@ -15,7 +15,7 @@ confirmed(person, "Lauren").
     confirmed(day, Day);
     schedule(Day, arrival_home, ArrivalHome);
     suggestion_for_user(time, Day, Time);
-    !expect_response("/time/suggestion/home_arrival_1", [arrival_home(ArrivalHome), Time]).
+    !expect_response("/time/suggestion/home_arrival_1", [arrival_home(ArrivalHome), suggested_time(Time)]).
     
     
 +response("/time/suggestion/home_arrival_1", confirmation, InputValues) <-

--- a/asl/ava/time.asl
+++ b/asl/ava/time.asl
@@ -18,11 +18,11 @@ confirmed(person, "Lauren").
     !expect_response("/time/suggestion/home_arrival_1", [arrival_home(ArrivalHome), suggested_time(Time)]).
     
     
-+response("/time/suggestion/home_arrival_1", confirmation, InputValues) <-
++response(find_time_option, confirmation, InputValues) <-
     .log("confirmation received", _);
     !indicate_switch_person.
 
     
 +!indicate_switch_person <-
     confirmed(person, Person);
-    !statement("/operational/switch_person_1", [Person]).
+    !statement("/operational/switch_person_1", [name_person(Person)]).

--- a/ava/avaagent.py
+++ b/ava/avaagent.py
@@ -5,6 +5,7 @@ from spade_bdi.bdi import BDIAgent
 from spade.template import Template
 from spade_bdi.bdi import parse_literal
 from typing import Union
+import agentspeak
 
 
 class AvaAgent(BDIAgent):
@@ -38,6 +39,18 @@ class AvaAgent(BDIAgent):
                 response = input(question + "\n" + str(readable) + "\n: ")
                 if response in readable:
                     return options[readable.index(response)]
+
+            @self.agent.bdi_actions.add(".get_parent_intention", 1)
+            def _get_parent_intention(agent, term, intention):
+                calling_intention = intention.head_term.functor
+
+                for intention_stack in agent.intentions:
+                    latest_intention = intention_stack[len(intention_stack) - 1]
+                    if latest_intention.head_term.functor == calling_intention:
+                        parent_intention = intention_stack[len(intention_stack) - 2]
+                        if agentspeak.unify(term.args[0], parent_intention.head_term, intention.scope, intention.stack):
+                            yield
+
 
         async def run(self):
             await super().run()

--- a/ava/directive.py
+++ b/ava/directive.py
@@ -1,15 +1,17 @@
 from agentspeak import Literal
-
+from definitions import *
 
 class Directive:
-    def __init__(self, eliciting_utterance, intents=None):
-        self.utterance_id = eliciting_utterance
+    def __init__(self, eliciting_utterance_id, eliciting_intention=None, intents=None):
+        self.utterance_id = eliciting_utterance_id
+        self.eliciting_intention = eliciting_intention
+
         self.intents = intents if isinstance(intents, list) else [intents]
         self.entities = []
         self.raw_wit_data = {}
 
     def has_intents(self):
-        return len(self.intents) > 1 or self.intents[0] != "NO_INTENT_DETECTED"
+        return len(self.intents) > 1 or self.intents[0] != NO_INTENT_DETECTED
 
     def add_entity(self, label, value):
         self.entities.append((label, value))
@@ -22,6 +24,8 @@ class Directive:
 
         intent_literal = Literal(self.intents[0])
 
-        arguments = (self.utterance_id, intent_literal, entities)
+        eliciting_intention_literal = Literal(self.eliciting_intention)
+
+        arguments = (eliciting_intention_literal, intent_literal, entities)
 
         return Literal("response", arguments)

--- a/ava/environment.py
+++ b/ava/environment.py
@@ -7,7 +7,13 @@ from ava.nlpcontroller import NLPController
 from ava.utterancedb import UtteranceDB
 from ava.exceptions import MissingAvaExcpetion
 
+
+
 class Environment:
+    RECEIVED_USER_RESPONSE = 1
+    STATEMENT_FINISHED = 2
+    NO_INTENT_DETECTED = 3
+
     def __init__(self, agent_jid, user_controller_jid):
         log.debug("environment init")
 

--- a/ava/environment.py
+++ b/ava/environment.py
@@ -10,9 +10,6 @@ from ava.exceptions import MissingAvaExcpetion
 
 
 class Environment:
-    RECEIVED_USER_RESPONSE = 1
-    STATEMENT_FINISHED = 2
-    NO_INTENT_DETECTED = 3
 
     def __init__(self, agent_jid, user_controller_jid):
         log.debug("environment init")
@@ -46,7 +43,8 @@ class Environment:
         self.setup_exit()
 
         self.ava.bdi.set_singleton_belief("started", "yes")
-        self.ava.bdi.add_achievement_goal("main")
+        # self.ava.bdi.add_achievement_goal("main")
+        self.ava.bdi.add_achievement_goal("test_get_intention")
         # self.ava.bdi.add_achievement_goal("capture_user_speech")
 
 

--- a/ava/environment.py
+++ b/ava/environment.py
@@ -44,7 +44,7 @@ class Environment:
 
         self.ava.bdi.set_singleton_belief("started", "yes")
         # self.ava.bdi.add_achievement_goal("main")
-        self.ava.bdi.add_achievement_goal("test_get_intention")
+        self.ava.bdi.add_achievement_goal("conversation_part")
         # self.ava.bdi.add_achievement_goal("capture_user_speech")
 
 

--- a/ava/environment.py
+++ b/ava/environment.py
@@ -43,8 +43,8 @@ class Environment:
         self.setup_exit()
 
         self.ava.bdi.set_singleton_belief("started", "yes")
-        # self.ava.bdi.add_achievement_goal("main")
-        self.ava.bdi.add_achievement_goal("conversation_part")
+        self.ava.bdi.add_achievement_goal("main")
+        # self.ava.bdi.add_achievement_goal("conversation_part")
         # self.ava.bdi.add_achievement_goal("capture_user_speech")
 
 

--- a/ava/input.py
+++ b/ava/input.py
@@ -3,7 +3,7 @@ from log import log_input as log, dump
 import time
 from multiprocessing import Queue
 from env import *
-
+from ava.environment import Environment as e
 
 class Input:
     def __init__(self, io_queue_out: Queue):
@@ -34,7 +34,7 @@ class Input:
                 parsed_user_input = self.queue.get()
                 if parsed_user_input:
                     log.debug(f"received parsed user input {dump(parsed_user_input)}")
-                    self.io_queue_out.put(("RECEIVED_USER_RESPONSE", (self.active_utterance_id, parsed_user_input)))
+                    self.io_queue_out.put((e.RECEIVED_USER_RESPONSE, (self.active_utterance_id, parsed_user_input)))
 
                     self.active_utterance_id = ""
                     stop_listening(wait_for_stop=False)

--- a/ava/input.py
+++ b/ava/input.py
@@ -3,7 +3,7 @@ from log import log_input as log, dump
 import time
 from multiprocessing import Queue
 from env import *
-from ava.environment import Environment as e
+from definitions import *
 
 class Input:
     def __init__(self, io_queue_out: Queue):
@@ -34,7 +34,7 @@ class Input:
                 parsed_user_input = self.queue.get()
                 if parsed_user_input:
                     log.debug(f"received parsed user input {dump(parsed_user_input)}")
-                    self.io_queue_out.put((e.RECEIVED_USER_RESPONSE, (self.active_utterance_id, parsed_user_input)))
+                    self.io_queue_out.put((RECEIVED_USER_RESPONSE, (self.active_utterance_id, parsed_user_input)))
 
                     self.active_utterance_id = ""
                     stop_listening(wait_for_stop=False)

--- a/ava/nlpcontroller.py
+++ b/ava/nlpcontroller.py
@@ -10,11 +10,15 @@ class NLPController:
         log.debug("init nlpc")
 
     def process(self, wit_data):
-        utterance_id, wit_response = wit_data
+        utterance, wit_response = wit_data
 
         intents = self.extract_intents(wit_response)
         # todo extract named entities
-        directive = Directive(utterance_id, intents)
+        directive = Directive(
+            eliciting_utterance_id=utterance.id,
+            eliciting_intention=utterance.eliciting_intention,
+            intents=intents
+        )
         directive.raw_wit_data = wit_response
         return directive
 

--- a/ava/nlpcontroller.py
+++ b/ava/nlpcontroller.py
@@ -2,7 +2,7 @@ from log import log_nlp as log
 from ava.directive import Directive
 import agentspeak as asp
 from spade_bdi.bdi import get_literal_from_functor_and_arguments
-
+from ava.environment import Environment as e
 
 class NLPController:
     def __init__(self):
@@ -20,7 +20,7 @@ class NLPController:
     def extract_intents(self, wit_dict):
         intent_array = self.keys_exists(wit_dict, "entities", "intent")
         if not intent_array:
-            return "NO_INTENT_DETECTED"
+            return e.NO_INTENT_DETECTED
         else:
             return [intent["value"] for intent in intent_array]
 

--- a/ava/nlpcontroller.py
+++ b/ava/nlpcontroller.py
@@ -2,7 +2,8 @@ from log import log_nlp as log
 from ava.directive import Directive
 import agentspeak as asp
 from spade_bdi.bdi import get_literal_from_functor_and_arguments
-from ava.environment import Environment as e
+from definitions import *
+
 
 class NLPController:
     def __init__(self):
@@ -20,7 +21,7 @@ class NLPController:
     def extract_intents(self, wit_dict):
         intent_array = self.keys_exists(wit_dict, "entities", "intent")
         if not intent_array:
-            return e.NO_INTENT_DETECTED
+            return NO_INTENT_DETECTED
         else:
             return [intent["value"] for intent in intent_array]
 

--- a/ava/output.py
+++ b/ava/output.py
@@ -5,7 +5,7 @@ from ava.input import Input
 from ava.utterancedb import UtteranceDB
 from multiprocessing import Queue
 from ava.exceptions import IOCNoUtteranceNotFoundInHistory
-
+from ava.environment import Environment as e
 
 class Output:
     def __init__(self, input: Input, history: list, io_queue_out: Queue):
@@ -40,7 +40,7 @@ class Output:
         if utterance.expects_response():
             self.input.listen(name)
         else:
-            self.io_queue_out.put(("STATEMENT_FINISHED", utterance))
+            self.io_queue_out.put((e.STATEMENT_FINISHED, utterance))
 
     def on_started_word(self, name, location, length):
         pass

--- a/ava/output.py
+++ b/ava/output.py
@@ -5,7 +5,7 @@ from ava.input import Input
 from ava.utterancedb import UtteranceDB
 from multiprocessing import Queue
 from ava.exceptions import IOCNoUtteranceNotFoundInHistory
-from ava.environment import Environment as e
+from definitions import *
 
 class Output:
     def __init__(self, input: Input, history: list, io_queue_out: Queue):
@@ -40,7 +40,7 @@ class Output:
         if utterance.expects_response():
             self.input.listen(name)
         else:
-            self.io_queue_out.put((e.STATEMENT_FINISHED, utterance))
+            self.io_queue_out.put((STATEMENT_FINISHED, utterance))
 
     def on_started_word(self, name, location, length):
         pass

--- a/ava/usercontroller.py
+++ b/ava/usercontroller.py
@@ -10,7 +10,7 @@ from spade_bdi.bdi import get_literal_from_functor_and_arguments
 from ava.nlpcontroller import NLPController
 from queue import Empty
 
-from ava.environment import Environment as e
+from definitions import *
 
 from ava.utterancedb import UtteranceDB
 
@@ -71,14 +71,14 @@ class UserController(BDIAgent):
             if response_from_ioc:
                 log.debug(response_from_ioc)
                 flag, payload = response_from_ioc
-                if flag == e.STATEMENT_FINISHED:
+                if flag == STATEMENT_FINISHED:
                     log.debug("statement finished")
                     utterance = payload
 
                     self.ava.bdi.add_belief_literal(utterance.to_statement_finished_belief())
 
                     pass
-                elif flag == e.RECEIVED_USER_RESPONSE:
+                elif flag == RECEIVED_USER_RESPONSE:
                     utterance_id, wit_response = payload
                     log.debug(f"wit response for transcript '{wit_response['_text']}' in response to utterance {utterance_id}")
 

--- a/ava/usercontroller.py
+++ b/ava/usercontroller.py
@@ -10,6 +10,8 @@ from spade_bdi.bdi import get_literal_from_functor_and_arguments
 from ava.nlpcontroller import NLPController
 from queue import Empty
 
+from ava.environment import Environment as e
+
 from ava.utterancedb import UtteranceDB
 
 
@@ -69,14 +71,14 @@ class UserController(BDIAgent):
             if response_from_ioc:
                 log.debug(response_from_ioc)
                 flag, payload = response_from_ioc
-                if flag == "STATEMENT_FINISHED":
+                if flag == e.STATEMENT_FINISHED:
                     log.debug("statement finished")
                     utterance = payload
 
                     self.ava.bdi.add_belief_literal(utterance.to_statement_finished_belief())
 
                     pass
-                elif flag == "RECEIVED_USER_RESPONSE":
+                elif flag == e.RECEIVED_USER_RESPONSE:
                     utterance_id, wit_response = payload
                     log.debug(f"wit response for transcript '{wit_response['_text']}' in response to utterance {utterance_id}")
 

--- a/ava/usercontroller.py
+++ b/ava/usercontroller.py
@@ -43,19 +43,18 @@ class UserController(BDIAgent):
             # await asyncio.sleep(0.5)
 
         async def handle_message_with_custom_ilf_type(self, message: Message):
-            log.critical(message.body)
-            functor, args = parse_literal(message.body)
+            # functor, args = parse_literal(message.body)
             # args = args[0]
             log.debug(f"received message with custom ilf type {message}")
 
 
 
             utterance = self.agent.db.get_by_agent_string(message.body)
+            log.critical(f"here {utterance.id}")
 
             if utterance is not None:
                 self.agent.io_queue_in.put(utterance)
                 await asyncio.sleep(3)
-                log.critical(f"here {utterance.identifier}")
             else:
                 log.error("no utterance received")
 
@@ -82,7 +81,10 @@ class UserController(BDIAgent):
                     utterance_id, wit_response = payload
                     log.debug(f"wit response for transcript '{wit_response['_text']}' in response to utterance {utterance_id}")
 
-                    directive = self.nlpc.process(payload)
+                    utterance = self.db.get_last_utterance(utterance_id)
+
+                    directive = self.nlpc.process((utterance, wit_response))
+
                     self.db.history.push(directive)
                     log.debug(f"received intents {directive.intents}")
                     if directive.has_intents():

--- a/ava/utterance.py
+++ b/ava/utterance.py
@@ -3,10 +3,10 @@ from agentspeak import Literal
 
 
 class Utterance:
-    def __init__(self, body, id, expects_response=True):
+    def __init__(self, body, id, expected_reactions=[]):
         self._body = body
         self.id: str = id
-        self._expects_response = expects_response
+        self._expected_reactions = expected_reactions
         self._fill_ins = []
         self.identifier = None
 
@@ -21,7 +21,7 @@ class Utterance:
             return self._body
 
     def expects_response(self):
-        return self._expects_response
+        return len(self._expected_reactions) > 0
 
     def to_statement_finished_belief(self):
 

--- a/ava/utterance.py
+++ b/ava/utterance.py
@@ -3,12 +3,13 @@ from agentspeak import Literal
 
 
 class Utterance:
-    def __init__(self, body, id, expected_reactions=[]):
+    def __init__(self, body, id, expected_reactions=[], eliciting_intention=None):
         self._body = body
         self.id: str = id
         self._expected_reactions = expected_reactions
         self._fill_ins = []
         self.identifier = None
+        self.eliciting_intention = eliciting_intention
 
     # todo add a check whether the number of placeholders matches the number of fill ins
     def get_body(self):

--- a/ava/utterance.py
+++ b/ava/utterance.py
@@ -7,19 +7,19 @@ class Utterance:
         self._body = body
         self.id: str = id
         self._expected_reactions = expected_reactions
-        self._fill_ins = []
+        self._fill_ins = {}
         self.identifier = None
         self.eliciting_intention = eliciting_intention
 
     # todo add a check whether the number of placeholders matches the number of fill ins
     def get_body(self):
-        if "{}" in self._body:
-            if len(self._fill_ins):
-                return self._body.format(*self._fill_ins)
-            else:
-                raise MissingFillInsExceptions
+
+        body_string = self._body.format(**self._fill_ins)
+
+        if "{" in body_string or "}" in body_string:
+            raise MissingFillInsExceptions
         else:
-            return self._body
+            return body_string
 
     def expects_response(self):
         return len(self._expected_reactions) > 0
@@ -32,7 +32,7 @@ class Utterance:
         yes_literal = Literal("yes")
         return Literal("statement_finished", (self.id, yes_literal))
 
-    def set_fill_ins(self, fillins: list):
+    def set_fill_ins(self, fillins: dict):
         self._fill_ins = fillins
 
     def get_fill_ins(self, i=None):

--- a/ava/utterancedb.py
+++ b/ava/utterancedb.py
@@ -45,7 +45,7 @@ class UtteranceDB:
         return process_layer("", self.db_raw)
 
 
-    def get(self, domain_string, fill_ins=[]):
+    def get(self, domain_string, fill_ins=[], eliciting_intention=None):
         matches = [utterance for utterance in self.db if domain_string in utterance.id]
         utterance = None
         if len(matches) == 1:
@@ -58,10 +58,14 @@ class UtteranceDB:
 
         utterance.set_fill_ins(fill_ins)
 
+        utterance.eliciting_intention = eliciting_intention
+
         self.history.push(utterance)
 
         return utterance
 
+    def get_last_utterance(self):
+        return self.history.get_last_utterance()
 
     def transform(self, id, data):
         return Utterance(
@@ -95,3 +99,19 @@ class UtteranceDB:
     def stop(self):
         log.debug("stopping db")
         self.history.serialize()
+
+    @staticmethod
+    def get_functor_and_argument_from_literal(literal_string: str, functor=None, strip=False):
+        if not functor: # extract functor at beginning of string
+            matches = re.search(rf"^([a-zA-Z_0-1]+)\(([^()]+)\)", literal_string)
+        else: # extract functor anywhere
+            matches = re.search(rf"({functor})\(([^()]+)\)", literal_string)
+
+        functor = matches.group(1)
+        argument = matches.group(2)
+
+        if strip:
+            argument = argument.strip('" ')
+
+        return functor, argument
+

--- a/ava/utterancedb.py
+++ b/ava/utterancedb.py
@@ -67,11 +67,11 @@ class UtteranceDB:
         return Utterance(
             id=id,
             body=data["body"],
-            expects_response=(data["expects_response"] if "expects_response" in data.keys() else True)
+            expected_reactions=(data["expected_reactions"] if "expected_reactions" in data.keys() else [])
         )
 
     def extract_data_from_agent_message_string(self, message: str):
-        """[time/suggestion/home_arrival_1, [6pm, 7:30pm]]"""
+        """[/time/suggestion/home_arrival_1, [6pm, 7:30pm]]"""
         uid = re.match("^\[([a-z\/_\d]+)", message)
         fillins_list_string = re.match("^\[.*\[(.*)\]\]$", message).groups(0)[0]
 

--- a/definitions.py
+++ b/definitions.py
@@ -3,3 +3,8 @@ import os
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 LOG_DIR = os.path.join(ROOT_DIR, 'logs')
 
+
+
+RECEIVED_USER_RESPONSE = 1
+STATEMENT_FINISHED = 2
+NO_INTENT_DETECTED = 3

--- a/storage/utterances.json
+++ b/storage/utterances.json
@@ -24,7 +24,7 @@
     },
     "operational": {
         "switch_person_1": {
-            "body": "Alright, I'll go talk to {} then.",
+            "body": "Alright, I'll go talk to {name_person} then.",
             "expects_response": false,
             "expected_reactions": []
         },
@@ -36,7 +36,7 @@
     "time": {
         "suggestion": {
             "home_arrival_1": {
-                "body": "Okay, let’s talk about the time, since with both places it would be good to make a reservation. I guess you’ll come home around {}, what do you think about going for dinner at {} then?",
+                "body": "Okay, let’s talk about the time, since with both places it would be good to make a reservation. I guess you’ll come home around {arrival_home}, what do you think about going for dinner at {suggested_time} then?",
                 "expected_reactions": [
                     "confirm",
                     "reject"

--- a/storage/utterances.json
+++ b/storage/utterances.json
@@ -7,6 +7,21 @@
             "body": "Speak."
         }
     },
+    "query": {
+        "accept": {
+            "event_context": {
+                "with_day_suggestion_1": {
+                    "body": "Of course! Let’s have a look at your schedule: You arrive in {}, {} seems to be free",
+                    "expects_response": false
+
+
+                },
+                "with_day_suggestion_2": {
+                    "body": "on {} but {} looks free. Should we take {} right away?"
+                }
+            }
+        }
+    },
     "operational": {
         "switch_person_1": {
             "body": "Alright, I'll go talk to {} then.",

--- a/tests/directive_test.py
+++ b/tests/directive_test.py
@@ -1,6 +1,6 @@
 from ava.directive import *
 from agentspeak import Literal
-
+from ava.utterance import Utterance
 
 def test_directive_has_attr_for_storing_raw_wit_data():
     directive = Directive("default", "confirmation")
@@ -10,7 +10,7 @@ def test_directive_has_attr_for_storing_raw_wit_data():
 
 
 def test_directive_can_add_entities():
-    directive = Directive("default", "confirmation")
+    directive = Directive("default", intents="confirmation")
 
     directive.add_entity("degree", 59)
 
@@ -18,7 +18,7 @@ def test_directive_can_add_entities():
 
 
 def test_entity_to_literal_transforms_the_label_to_literal():
-    directive = Directive("default", "confirmation")
+    directive = Directive("default", intents="confirmation")
     directive.add_entity("degree", 59)
 
     transformed = directive.entity_to_literal(directive.entities[0])
@@ -28,7 +28,7 @@ def test_entity_to_literal_transforms_the_label_to_literal():
 
 
 def test_to_response_belief_returns_a_belief_containing_the_uid_intent_and_all_entities():
-    directive = Directive("default", "confirmation")
+    directive = Directive(eliciting_utterance_id="/my/utterance", eliciting_intention="test_intention", intents="confirmation")
     directive.add_entity("degree", 59)
     directive.add_entity("centimeter", 20)
 
@@ -36,19 +36,28 @@ def test_to_response_belief_returns_a_belief_containing_the_uid_intent_and_all_e
 
     assert isinstance(belief_literal, Literal)
     assert belief_literal.functor == "response"
-    assert "default" in belief_literal.args
+
+    # intention literal
+    assert isinstance(belief_literal.args[0], Literal)
+    assert belief_literal.args[0].functor == "test_intention"
+
     assert belief_literal.args[1].functor == "confirmation"
     assert isinstance(belief_literal.args[2], tuple)
     assert len(belief_literal.args[2]) == 2
 
 
 def test_directive_without_entities_returns_response_literal_with_empty_tuple():
-    directive = Directive("default", "confirmation")
+    directive = Directive(
+        eliciting_utterance_id="default",
+        eliciting_intention="test_intention",
+        intents="confirmation"
+    )
     belief_literal = directive.to_response_belief()
 
     assert isinstance(belief_literal, Literal)
     assert belief_literal.functor == "response"
-    assert "default" in belief_literal.args
+    assert isinstance(belief_literal.args[0], Literal)
+    assert belief_literal.args[0].functor == "test_intention"
     assert belief_literal.args[1].functor == "confirmation"
     assert isinstance(belief_literal.args[2], tuple)
     assert len(belief_literal.args[2]) == 0

--- a/tests/nlpcontroller_test.py
+++ b/tests/nlpcontroller_test.py
@@ -1,5 +1,6 @@
 from ava.nlpcontroller import NLPController
 from ava.directive import Directive
+from definitions import *
 
 
 def test_nlpc_extracts_single_intent_from_dict():
@@ -54,8 +55,8 @@ def test_nlpc_returns_flag_for_missing_intent():
     nlpc = NLPController()
 
     intents = nlpc.extract_intents(wit_dict)
-    assert isinstance(intents, str)
-    assert intents == "NO_INTENT_DETECTED"
+    assert isinstance(intents, int)
+    assert intents == NO_INTENT_DETECTED
 
 
 def test_process_method_extracts_intent_correctly_from_tuple():

--- a/tests/nlpcontroller_test.py
+++ b/tests/nlpcontroller_test.py
@@ -1,7 +1,7 @@
 from ava.nlpcontroller import NLPController
 from ava.directive import Directive
 from definitions import *
-
+from ava.utterance import Utterance
 
 def test_nlpc_extracts_single_intent_from_dict():
     wit_dict = {
@@ -69,7 +69,7 @@ def test_process_method_extracts_intent_correctly_from_tuple():
         }]
     },
     'msg_id': '1yoIkxVstxREydBbY'}
-    response = ("default", wit_dict)
+    response = (Utterance("hello", "default"), wit_dict)
 
     nlpc = NLPController()
 
@@ -89,7 +89,7 @@ def test_directive_contains_wit_data_when_created_by_nlpc():
         }]
     },
     'msg_id': '1yoIkxVstxREydBbY'}
-    response = ("default", wit_dict)
+    response = (Utterance("hello", "default"), wit_dict)
 
     nlpc = NLPController()
 

--- a/tests/utterance_test.py
+++ b/tests/utterance_test.py
@@ -27,13 +27,13 @@ def test_utterance_raises_if_placeholder_in_string_but_no_fill_ins():
 
 
 def test_expects_response_method_returns_correct_value():
-    utterance = Utterance("blank {}", "default", expects_response=True)
+    utterance = Utterance("blank {}", "default", expected_reactions=["default"])
 
     assert utterance.expects_response()
 
 
 def test_utterance_can_generate_a_statement_finished_belief():
-    utterance = Utterance("blank {}", "default", expects_response=False)
+    utterance = Utterance("blank {}", "default")
 
     statement_finished_belief = utterance.to_statement_finished_belief()
 
@@ -46,7 +46,7 @@ def test_utterance_can_generate_a_statement_finished_belief():
 
 
 def test_utterance_throws_error_if_expects_response_and_statement_finished_goal_is_generated():
-    utterance = Utterance("blank {}", "default")
+    utterance = Utterance("blank {}", "default", expected_reactions=["default"])
 
     with pytest.raises(UtteranceExpectsResponseException):
         statement_finished_belief = utterance.to_statement_finished_belief()

--- a/tests/utterance_test.py
+++ b/tests/utterance_test.py
@@ -58,4 +58,9 @@ def test_u_has_no_public_fill_ins_property():
     assert not hasattr(utterance, "fill_ins")
 
 
+def test_u_can_take_an_eliciting_intention_as_an_optional_parameter():
+    utterance = Utterance("blank {}", "default", expected_reactions=["confirmation"], eliciting_intention="get_time_from_user")
+
+    assert hasattr(utterance, "eliciting_intention")
+    assert utterance.eliciting_intention == "get_time_from_user"
 

--- a/tests/utterance_test.py
+++ b/tests/utterance_test.py
@@ -4,8 +4,8 @@ import pytest
 from agentspeak import Literal
 
 def test_utterance_can_replace_placeholders_in_body_with_fill_ins():
-    utterance = Utterance("blank {}", "default")
-    utterance.set_fill_ins(["hello"])
+    utterance = Utterance("blank {greeting}", "default")
+    utterance.set_fill_ins({"greeting": "hello"})
 
     body = utterance.get_body()
     assert body == "blank hello"
@@ -19,21 +19,21 @@ def test_utterance_can_deal_with_empty_fill_in_list():
 
 
 def test_utterance_raises_if_placeholder_in_string_but_no_fill_ins():
-    utterance = Utterance("blank {}", "default")
+    utterance = Utterance("blank {greeting}", "default")
 
 
-    with pytest.raises(MissingFillInsExceptions):
+    with pytest.raises(KeyError):
         body = utterance.get_body()
 
 
 def test_expects_response_method_returns_correct_value():
-    utterance = Utterance("blank {}", "default", expected_reactions=["default"])
+    utterance = Utterance("blank {greeting}", "default", expected_reactions=["default"])
 
     assert utterance.expects_response()
 
 
 def test_utterance_can_generate_a_statement_finished_belief():
-    utterance = Utterance("blank {}", "default")
+    utterance = Utterance("blank {greeting}", "default")
 
     statement_finished_belief = utterance.to_statement_finished_belief()
 
@@ -46,7 +46,7 @@ def test_utterance_can_generate_a_statement_finished_belief():
 
 
 def test_utterance_throws_error_if_expects_response_and_statement_finished_goal_is_generated():
-    utterance = Utterance("blank {}", "default", expected_reactions=["default"])
+    utterance = Utterance("blank {greeting}", "default", expected_reactions=["default"])
 
     with pytest.raises(UtteranceExpectsResponseException):
         statement_finished_belief = utterance.to_statement_finished_belief()
@@ -54,12 +54,12 @@ def test_utterance_throws_error_if_expects_response_and_statement_finished_goal_
 
 
 def test_u_has_no_public_fill_ins_property():
-    utterance = Utterance("blank {}", "default")
+    utterance = Utterance("blank {greeting}", "default")
     assert not hasattr(utterance, "fill_ins")
 
 
 def test_u_can_take_an_eliciting_intention_as_an_optional_parameter():
-    utterance = Utterance("blank {}", "default", expected_reactions=["confirmation"], eliciting_intention="get_time_from_user")
+    utterance = Utterance("blank {greeting}", "default", expected_reactions=["confirmation"], eliciting_intention="get_time_from_user")
 
     assert hasattr(utterance, "eliciting_intention")
     assert utterance.eliciting_intention == "get_time_from_user"

--- a/tests/utterancedb_test.py
+++ b/tests/utterancedb_test.py
@@ -169,6 +169,34 @@ def test_incomplete_domain_string_returns_random_item_from_module():
     assert isinstance(random_utterance, Utterance)
 
 
+def test_udb_get_can_take_the_eliciting_intention_as_a_parameter():
+    db = get_udb()
+
+    utterance = db.get("/standard/number_one", eliciting_intention="get_time_from_user")
+
+    assert isinstance(utterance, Utterance)
+    assert utterance.eliciting_intention == "get_time_from_user"
+
+
+# [utterance_id("/time/suggestion/home_arrival_1"), eliciting_intention("my_test_intention"), fill_ins([arrival_home("6pm"), suggested_time("7:30pm")])]
+
+
+def test_udb_can_extract_literal_functor_and_body_from_string():
+    literal_string = "utterance_id(\"/time/suggestion/home_arrival_1\")"
+
+    functor, argument = UtteranceDB.get_functor_and_argument_from_literal(literal_string, strip=True)
+
+    assert functor == "utterance_id"
+    assert argument == "/time/suggestion/home_arrival_1"
+
+
+def test_udb_can_extract_arguments_for_given_functor():
+    literal_string = 'utterance_id("/time/suggestion/home_arrival_1"), depart_time(6:30pm), another_parameter("hello")'
+
+    functor, argument = UtteranceDB.get_functor_and_argument_from_literal(literal_string, functor="depart_time")
+
+    assert functor == "depart_time"
+    assert argument == "6:30pm"
 
 
 
@@ -264,6 +292,17 @@ def test_udb_stores_utterance_in_history_when_getting():
 
     assert isinstance(db.history.get_last_utterance(), Utterance)
     assert db.history.get_last_utterance().id == "/time/suggestion/sub_module/another_module/number_one"
+
+
+def test_udb_can_get_last_utterance_form_history_with_own_method():
+    db = get_udb()
+    utterance = db.get("/standard/number_one")
+
+    last_utterance = db.get_last_utterance()
+
+    assert utterance == last_utterance
+
+
 
 
 

--- a/tests/utterancedb_test.py
+++ b/tests/utterancedb_test.py
@@ -140,8 +140,8 @@ def test_if_db_get_returns_a_valid_utterance_instance():
 
 def test_db_get_accepts_fill_ins():
     db = get_udb()
-    utterance = db.get("/standard/number_one", ["robert"])
-    assert utterance.get_fill_ins(0) == "robert"
+    utterance = db.get("/standard/number_one", {"name": "robert"})
+    assert utterance.get_fill_ins("name") == "robert"
 
 
 def test_incomplete_domain_string_returns_random_item_from_module():
@@ -178,102 +178,90 @@ def test_udb_get_can_take_the_eliciting_intention_as_a_parameter():
     assert utterance.eliciting_intention == "get_time_from_user"
 
 
-# [utterance_id("/time/suggestion/home_arrival_1"), eliciting_intention("my_test_intention"), fill_ins([arrival_home("6pm"), suggested_time("7:30pm")])]
-
-
 def test_udb_can_extract_literal_functor_and_body_from_string():
     literal_string = "utterance_id(\"/time/suggestion/home_arrival_1\")"
 
-    functor, argument = UtteranceDB.get_functor_and_argument_from_literal(literal_string, strip=True)
+    functor, argument = UtteranceDB.get_functor_and_argument_from_literal(literal_string)
 
     assert functor == "utterance_id"
     assert argument == "/time/suggestion/home_arrival_1"
 
 
-def test_udb_can_extract_arguments_for_given_functor():
+def test_udb_can_extract_arguments_for_named_functor():
     literal_string = 'utterance_id("/time/suggestion/home_arrival_1"), depart_time(6:30pm), another_parameter("hello")'
 
-    functor, argument = UtteranceDB.get_functor_and_argument_from_literal(literal_string, functor="depart_time")
+    argument = UtteranceDB.get_argument_for_functor("depart_time", literal_string)
 
-    assert functor == "depart_time"
     assert argument == "6:30pm"
 
 
+def test_udb_can_extract_list_content_as_argument_for_functor():
+    literal_string = '[utterance_id("/time/suggestion/home_arrival_1"), eliciting_intention("my_test_intention"), fill_ins([arrival_home("6pm"), suggested_time("7:30pm")])]'
+
+    fill_ins_string = UtteranceDB.get_argument_for_functor("fill_ins", literal_string, extract_list=True)
+
+    assert fill_ins_string == 'arrival_home("6pm"), suggested_time("7:30pm")'
+
 
 def test_if_db_can_parse_uid_and_a_list_of_options_from_the_agent_message_body():
-    message_body = "[/time/suggestion/option_1, [6pm, 7:30pm]]"
+    message_body = '[utterance_id("/time/suggestion/home_arrival_1"), eliciting_intention("my_test_intention"), fill_ins([arrival_home("6pm"), suggested_time("7:30pm")])]'
 
-    db = UtteranceDB(DB_FILE)
-    db.setup()
+    db = get_udb()
 
-    uid, fill_ins = db.extract_data_from_agent_message_string(message_body)
+    data = db.extract_data_from_agent_message_string(message_body)
 
-    assert len(fill_ins) == 2
-    assert uid == "/time/suggestion/option_1"
-    assert fill_ins[0] == "6pm"
-    assert fill_ins[1] == "7:30pm"
+
+    assert len(list(data.keys())) == 3
+    assert data["utterance_id"] == "/time/suggestion/home_arrival_1"
+    assert data["eliciting_intention"] == "my_test_intention"
+    assert isinstance(data["fill_ins"], dict)
+    assert "arrival_home" in data["fill_ins"].keys()
+    assert "suggested_time" in data["fill_ins"].keys()
+    assert data["fill_ins"]["arrival_home"] == "6pm"
+    assert data["fill_ins"]["suggested_time"] == "7:30pm"
 
 
 def test_message_parser_can_deal_with_empty_list():
-    message_body = "[/time_suggestion_based_on_home_arrival_1, []]"
+    message_body = '[utterance_id("/time/suggestion/home_arrival_1"), eliciting_intention("my_test_intention"), fill_ins([])]'
+
 
     db = UtteranceDB(DB_FILE)
     db.setup()
 
-    uid, fill_ins = db.extract_data_from_agent_message_string(message_body)
+    data = db.extract_data_from_agent_message_string(message_body)
 
-    assert len(fill_ins) == 0
-    assert type(fill_ins) == list
-    assert uid == "/time_suggestion_based_on_home_arrival_1"
+    assert len(list(data["fill_ins"].keys())) == 0
+    assert type(data["fill_ins"]) == dict
+    assert data["utterance_id"] == "/time/suggestion/home_arrival_1"
 
 
 def test_get_by_agent_string_returns_utterance_instance_when_getting_a_well_formed_string():
-    message_body = "[/time/suggestion/default, []]"
-
-    db = UtteranceDB(DB_FILE)
-    db.setup()
-
-    utterance = db.get_by_agent_string(message_body)
-
-    assert isinstance(utterance, Utterance)
-    assert utterance.get_fill_ins() == []
-    assert utterance.id == "/time/suggestion/default"
-
-
-def test_get_by_agent_string_returns_utterance_with_existing_fill_ins():
-    message_body = "[/standard/number_one, [45, 69, Robert]]"
+    message_body = '[utterance_id("/standard/number_one"), eliciting_intention("my_test_intention"), fill_ins([])]'
 
     db = get_udb()
 
     utterance = db.get_by_agent_string(message_body)
 
     assert isinstance(utterance, Utterance)
-    assert utterance.get_fill_ins() == ["45", "69", "Robert"]
+    assert utterance.get_fill_ins() == {}
+    assert utterance.id == "/standard/number_one"
+
+
+def test_get_by_agent_string_returns_utterance_with_existing_fill_ins():
+    message_body = '[utterance_id("/standard/number_one"), eliciting_intention("my_test_intention"), fill_ins([arrival_home("6pm"), suggested_time("7:30pm")])]'
+
+    db = get_udb()
+
+    utterance = db.get_by_agent_string(message_body)
+
+    assert isinstance(utterance, Utterance)
+    assert utterance.get_fill_ins() == {"suggested_time": "7:30pm", "arrival_home": "6pm"}
     assert utterance.id == "/standard/number_one"
 
 
 def test_udb_raises_excpetion_if_no_utterance_was_found():
 
-    db = UtteranceDB(DB_FILE)
-    db.db_raw = {"time": {
-        "suggestion": {
-            "sub_module": {
-                "another_module": {
-                    "number_one": {
-                        "body": "this is my time suggestion one"
-                    },
-                    "number_two": {
-                        "body": "this is my time suggestion two"
-                    },
-                    "number_three": {
-                        "body": "this is my time suggestion three"
-                    },
-                }
-            }
-        }
-    }}
-    db.db = db.process_modules()
-
+    db = get_udb()
 
     with pytest.raises(UtteranceNotFoundException):
         utterance = db.get("/this/is/missing")
@@ -303,6 +291,14 @@ def test_udb_can_get_last_utterance_form_history_with_own_method():
     assert utterance == last_utterance
 
 
+def test_udb_can_get_last_utterance_form_history_by_uid_with_own_method():
+    db = get_udb()
+    utterance = db.get("/standard/number_one")
+    next_utterance = db.get("/time/suggestion/sub_module/another_module/number_one")
+
+    last_utterance = db.get_last_utterance("/standard/number_one")
+
+    assert utterance == last_utterance
 
 
 
@@ -328,7 +324,7 @@ def get_udb():
         },
         "standard": {
             "number_one": {
-                "body": "this is a sample"
+                "body": "this is a sample for {name}"
             }
         }
     }

--- a/tests/utterancedb_test.py
+++ b/tests/utterancedb_test.py
@@ -90,10 +90,10 @@ def test_processing_of_multiple_dimensions():
 
 def test_if_conversion_from_dict_data_to_utterance_object_works_well():
     db = UtteranceDB(DB_FILE)
-    utterance = db.transform("time/suggestions/number_one", {"body": "Hey this is me", "expects_response": True})
+    utterance = db.transform("/time/suggestions/number_one", {"body": "Hey this is me", "expected_reactions": ["default"]})
 
     assert isinstance(utterance, Utterance)
-    assert utterance.id == "time/suggestions/number_one"
+    assert utterance.id == "/time/suggestions/number_one"
     assert utterance.get_body() == "Hey this is me"
     assert utterance.expects_response() is True
 
@@ -102,7 +102,7 @@ def test_if_conversion_works_if_no_expects_response_is_set():
     db = UtteranceDB(DB_FILE)
 
 
-    utterance = db.transform("/hello_1", {"body": "Hey this is me"})
+    utterance = db.transform("/hello_1", {"body": "Hey this is me", "expected_reactions": ["default"]})
     assert isinstance(utterance, Utterance)
     assert utterance.id == "/hello_1"
     assert utterance.get_body() == "Hey this is me"


### PR DESCRIPTION
Placeholders in utterances use named placeholders now e.g. `{greeting} world`.
The fill ins in ASL are transferred as literals with one argument where the functor is the placeholder name and the argument is the fill in. e.g. `greeting(hello)`.

When Ava expects a response from the user the utterance accepts the name of the calling intention. The user response is transferred as a belief with the following pattern 

`response(calling_intention, user-intent, [entities])`